### PR TITLE
Fix conditional config

### DIFF
--- a/helm/appcatalog-chart/Chart.yaml
+++ b/helm/appcatalog-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: appcatalog-chart
-version: 0.1.0-[[ .SHA ]]
+version: 0.1.1-[[ .SHA ]]
 description: App catalog Helm chart packages AppCatalog CR and any accompanying ConfigMap/Secret resources as a single installable unit for use in `opsctl ensure appcatalogs` command.

--- a/helm/appcatalog-chart/templates/configmap.yaml
+++ b/helm/appcatalog-chart/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.appCatalog.config.configMap }}
+{{ if and .Values.appCatalog.config .Values.appCatalog.config.configMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/appcatalog-chart/templates/secret.yaml
+++ b/helm/appcatalog-chart/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.appCatalog.config.secret }}
+{{ if and .Values.appCatalog.config .Values.appCatalog.config.secret }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
`configMap` and `secret` are optional for an app catalog. `appcatalog` Helm chart by default includes both `configMap` and `secret` structure. To easily override the default, to unset both `configMap` and `secret` for an `appcatalog` Helm release, one should be able to just set `appCatalog.config: null` value. This was partially supported in initial version of the appcatalog Helm chart and this fix makes this fully functional.