### PR TITLE
Config redesign

### DIFF
--- a/helm/appcatalog-chart/Chart.yaml
+++ b/helm/appcatalog-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: appcatalog-chart
-version: 0.1.2-[[ .SHA ]]
+version: 0.1.3-[[ .SHA ]]
 description: App catalog Helm chart packages AppCatalog CR and any accompanying ConfigMap/Secret resources as a single installable unit for use in `opsctl ensure appcatalogs` command.

--- a/helm/appcatalog-chart/values.yaml
+++ b/helm/appcatalog-chart/values.yaml
@@ -18,10 +18,8 @@ appCatalog:
 
 configMap:
   values:
-    Installation:
-      V1:
-        API:
-          Address: ""
+    image:
+      registry: "quay.io"
 
 secret:
   values:

--- a/helm/appcatalog-chart/values.yaml
+++ b/helm/appcatalog-chart/values.yaml
@@ -12,19 +12,17 @@ appCatalog:
     configMap:
       name: ""
       namespace: "default"
-    secret:
-      name: ""
-      namespace: "default"
+### Example Secret metadata ###
+#    secret:
+#      name: ""
+#      namespace: "default"
 
 configMap:
   values:
     image:
       registry: "quay.io"
 
-secret:
-  values:
-    Installation:
-      V1:
-        Secret:
-          API:
-            token: ""
+### Example Secret configuration structure ###
+#secret:
+#  values:
+#    token: ""


### PR DESCRIPTION
This PR updates configuration structure and defaults of appcatalog Helm chart based on learnings from first application of the chart for managing giantswarm-incubator appcatalog definition (see https://github.com/giantswarm/installations/pull/764)
- use more meaningful defaults and and adjust structure of appcatalog ConfigMap
- still support but default to no appcatalog level Secret