### PR TITLE
Format ConfigMap values as YAML

### DIFF
--- a/helm/appcatalog-chart/Chart.yaml
+++ b/helm/appcatalog-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: appcatalog-chart
-version: 0.1.3-[[ .SHA ]]
+version: 0.1.4-[[ .SHA ]]
 description: App catalog Helm chart packages AppCatalog CR and any accompanying ConfigMap/Secret resources as a single installable unit for use in `opsctl ensure appcatalogs` command.

--- a/helm/appcatalog-chart/templates/configmap.yaml
+++ b/helm/appcatalog-chart/templates/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: "{{ .Values.appCatalog.config.configMap.namespace }}"
 data:
   values: |
-    {{ .Values.configMap.values }}
-{{ end }}{{ end }}
+{{- toYaml .Values.configMap.values | trim | nindent 4 }}
+{{- end }}{{ end -}}


### PR DESCRIPTION
While testing https://github.com/giantswarm/installations/pull/764 with appcatalog HelmChart 0.1.3, appcatalog release installation was failing since default configMap values were not being formatted correctly into the template.

This PR ensures YAML formatting of ConfigMap values.