### PR TITLE
fix secret and configmap templating

### DIFF
--- a/helm/appcatalog-chart/templates/configmap.yaml
+++ b/helm/appcatalog-chart/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.appCatalog.config }}{{ if .Values.appCatalog.config.configMap }}
+{{ if and .Values.appCatalog.config .Values.appCatalog.config.configMap .Values.configMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +7,4 @@ metadata:
 data:
   values: |
 {{- toYaml .Values.configMap.values | trim | nindent 4 }}
-{{- end }}{{ end -}}
+{{ end -}}

--- a/helm/appcatalog-chart/templates/secret.yaml
+++ b/helm/appcatalog-chart/templates/secret.yaml
@@ -1,10 +1,11 @@
-{{ if .Values.appCatalog.config }}{{ if .Values.appCatalog.config.secret }}
+{{ if and .Values.appCatalog.config .Values.appCatalog.config.secret .Values.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ .Values.appCatalog.config.secret.name }}"
   namespace: "{{ .Values.appCatalog.config.secret.namespace }}"
 data:
-  values: {{ toYaml .Values.secret.values | b64enc | quote }}
+  values: |
+{{- toYaml .Values.secret.values | b64enc | quote | nindent 4 }}
 type: Opaque
-{{ end }}{{ end }}
+{{ end -}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6847

This PR fixes an issue where templating fails when no value is given for the secret.


```
$ cat test.yaml
appCatalog:
  name: "name"
  title: "title"
  description: "description"
  logoUrl: "logo"
  storage:
    url: "url"
  config:
    configMap:
      name: "configmap"
      namespace: "configmap-ns"
    secret:
      name: "secret"
      namespace: "secret-ns"
configMap: null

$ helm template -f test.yaml ./helm/appcatalog-chart
Error: render error in "appcatalog-chart/templates/secret.yaml": template: appcatalog-chart/templates/secret.yaml:8:27: executing "appcatalog-chart/templates/secret.yaml" at <.Values.secret.values>: nil pointer evaluating interface {}.values

```

We need this in order to configure a catalog which is referring to already existing configMap and/or secret.