### PR TITLE
Fixing error types

### DIFF
--- a/appcatalog.go
+++ b/appcatalog.go
@@ -55,7 +55,7 @@ func GetLatestVersion(ctx context.Context, storageURL, app string) (string, erro
 // NewTarballURL returns the chart tarball URL for the specified app and version.
 func NewTarballURL(baseURL string, appName string, version string) (string, error) {
 	if baseURL == "" || appName == "" || version == "" {
-		return "", microerror.Maskf(invalidTarballError, "baseURL %#q, appName %#q, release %#q should not be empty", baseURL, appName, version)
+		return "", microerror.Maskf(executionFailedError, "baseURL %#q, appName %#q, release %#q should not be empty", baseURL, appName, version)
 	}
 	u, err := url.Parse(baseURL)
 	if err != nil {

--- a/error.go
+++ b/error.go
@@ -2,13 +2,8 @@ package appcatalog
 
 import "github.com/giantswarm/microerror"
 
-var invalidTarballError = &microerror.Error{
-	Kind: "invalidTarballError",
-}
-
-// IsInvalidTarballError asserts invalidTarballError.
-func IsInvalidTarballError(err error) bool {
-	return microerror.Cause(err) == invalidTarballError
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
 }
 
 var notFoundError = &microerror.Error{


### PR DESCRIPTION
Following https://github.com/giantswarm/appcatalog/pull/12

Change the error type into `executionFailedError` and remove the relevant matcher. 