### PR TITLE
Align appcatalog config variable names with CRD

### DIFF
--- a/helm/appcatalog-chart/values.yaml
+++ b/helm/appcatalog-chart/values.yaml
@@ -5,9 +5,9 @@ appCatalog:
   name: ""
   title: ""
   description: ""
-  logoUrl: "http://giantswarm.com/catalog-logo.png"
+  logoURL: "http://giantswarm.com/catalog-logo.png"
   storage:
-    url: "https://giantswarm.github.com/sample-catalog/"
+    URL: "https://giantswarm.github.com/changeme-catalog/"
   config:
     configMap:
       name: ""


### PR DESCRIPTION
See https://github.com/giantswarm/apiextensions/blob/master/pkg/apis/application/v1alpha1/app_catalog_types.go#L68

Inconsistency was misleading e.g. see https://gigantic.slack.com/archives/C76JX6YLQ/p1572335788068100