### PR TITLE
Using appVersion for matching

### DIFF
--- a/appcatalog.go
+++ b/appcatalog.go
@@ -20,21 +20,21 @@ func GetLatestChart(ctx context.Context, storageURL, app, appVersion string) (st
 		return "", microerror.Mask(err)
 	}
 
-		entries, ok := index.Entries[app]
-		if !ok {
-			return "", microerror.Maskf(notFoundError, "no app %#q in index.yaml", app)
-		}
+	entries, ok := index.Entries[app]
+	if !ok {
+		return "", microerror.Maskf(notFoundError, "no app %#q in index.yaml", app)
+	}
 
-		if appVersion != "" {
-			for _, entry := range entries {
-				if entry.Version == appVersion {
-					return entry.Urls[0], nil
-				}
+	if appVersion != "" {
+		for _, entry := range entries {
+			if entry.Version == appVersion {
+				return entry.Urls[0], nil
 			}
-			return "", microerror.Maskf(notFoundError, "no app %#q in index.yaml with given appVersion %#q", app, appVersion)
 		}
+		return "", microerror.Maskf(notFoundError, "no app %#q in index.yaml with given appVersion %#q", app, appVersion)
+	}
 
-		return entries[0].Urls[0], nil
+	return entries[0].Urls[0], nil
 }
 
 // GetLatestVersion returns the latest app version for the specified storage URL and app


### PR DESCRIPTION
After we got chart-operator flatten, I would like to use `appVersion` to match the chart version in app catalog. 
```
  - apiVersion: v1
    appVersion: 0.13.1-dev
    created: "2020-04-24T07:30:34.415911306Z"
    description: A Helm chart for the chart-operator
    digest: ab57472734c09d9917272ddce4407a45c2ed237bcc27f26a88b8585cb326efc0
    home: https://github.com/giantswarm/chart-operator
    name: chart-operator
    urls:
    - https://giantswarm.github.com/default-test-catalog/chart-operator-0.13.0-cabc326450846735cd579454be8c945465a9175e.tgz
    version: 0.13.0-cabc326450846735cd579454be8c945465a9175e
  - apiVersion: v1
    appVersion: 0.13.1-dev
    created: "2020-04-24T07:40:22.969695807Z"
    description: A Helm chart for the chart-operator
    digest: 7c1cfaf25e6a34e7598fb3de5a213998857e0d2d9b69669b79f5bafd11b3506e
    home: https://github.com/giantswarm/chart-operator
    name: chart-operator
    urls:
    - https://giantswarm.github.com/default-test-catalog/chart-operator-0.13.0-c7b983c5f8ef19e6d7b8ff9e260fe665ec4a5210.tgz
    version: 0.13.0-c7b983c5f8ef19e6d7b8ff9e260fe665ec4a5210
```