### PR TITLE
Align ConfigMap & Secret naming defaults

### DIFF
--- a/helm/appcatalog-chart/templates/_resource.tpl
+++ b/helm/appcatalog-chart/templates/_resource.tpl
@@ -1,7 +1,7 @@
 {{- define "resource.configmap.name" -}}
 {{- if and .Values.appCatalog.config .Values.appCatalog.config.configMap -}}
 {{- if eq .Values.appCatalog.config.configMap.name "" -}}
-{{- .Values.appCatalog.name -}}
+{{- .Values.appCatalog.name -}}-catalog
 {{- else -}}
 {{ .Values.appCatalog.config.configMap.name }}
 {{- end -}}
@@ -11,7 +11,7 @@
 {{- define "resource.secret.name" -}}
 {{- if and .Values.appCatalog.config .Values.appCatalog.config.secret -}}
 {{- if eq .Values.appCatalog.config.secret.name "" -}}
-{{- .Values.appCatalog.name -}}
+{{- .Values.appCatalog.name -}}-catalog
 {{- else -}}
 {{ .Values.appCatalog.config.secret.name }}
 {{- end -}}

--- a/helm/appcatalog-chart/values.yaml
+++ b/helm/appcatalog-chart/values.yaml
@@ -11,11 +11,11 @@ appCatalog:
   config:
     configMap:
       name: ""
-      namespace: "default"
+      namespace: "giantswarm"
       managed: true
       values:
     secret:
       name: ""
-      namespace: "default"
+      namespace: "giantswarm"
       managed: true
       values:


### PR DESCRIPTION
Some catalog ConfigMaps and Secrets had -catalog suffix, some didn't. With this PR all ConfigMaps and Secrets which don't explicitly set the name, will have one automatically generated from catalog name + "-catalog" suffix.

Similarly, most of the catalog ConfigMaps and Secrets were in giantswarm repo. This aligns the default in appcatalog chart, with real world most common use case, so it doesn't have to be overridden.

 There will be a related follow up PRs in installations repo and opsctl.