### PR TITLE
Support catalog-visibility annotation

### DIFF
--- a/helm/appcatalog-chart/templates/appcatalog.yaml
+++ b/helm/appcatalog-chart/templates/appcatalog.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ .Values.appCatalog.name }}"
   labels:
     application.giantswarm.io/catalog-type: "{{ .Values.appCatalog.catalogType }}"
+    application.giantswarm.io/catalog-visibility: "{{ .Values.appCatalog.catalogVisibility }}"
     app-operator.giantswarm.io/version: "{{ .Values.appOperator.version }}"
 spec:
   title: "{{ .Values.appCatalog.title }}"


### PR DESCRIPTION
catalog visibility is supposed to be public vs internal

catalog type would have stable and test only, as documented, where test means quality level, which is true not only for -test catalogs.

Will update appcatalog definitions in installations repo in followup PR. Then happa can start making use of it too.