### PR TITLE
Compare appVersion as substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Comparing `appVersion` as substring.
+
 ## [0.2.7] - 2020-07-23
 
 ### Changed

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/giantswarm/microerror"
@@ -62,7 +63,7 @@ func getLatestEntry(ctx context.Context, storageURL, app, appVersion string) (en
 	var latestCreated *time.Time
 	var latestEntry entry
 	for _, e := range entries {
-		if appVersion != "" && e.AppVersion != appVersion {
+		if appVersion != "" && !strings.HasSuffix(e.AppVersion, appVersion) {
 			continue
 		}
 


### PR DESCRIPTION
To fetch the chart with the correct appVersion, we should also allow comparing `appVersion` as a substring in appcatalog, since knowing the exact same appVersion we need to rely on `architect` (e.g. `architect project version`)