### PR TITLE
Compare version with appVersion, version fields in catalog index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Comparing `appVersion` with version, too.
+
 ## [0.3.0] - 2020-11-17
 
 ### Changed

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -67,11 +67,7 @@ func getLatestEntry(ctx context.Context, storageURL, app, appVersion string) (en
 			continue
 		}
 
-		if !strings.HasSuffix(e.AppVersion, appVersion) {
-			continue
-		}
-
-		if !strings.HasSuffix(e.Version, appVersion) {
+		if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
 			continue
 		}
 

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -63,7 +63,15 @@ func getLatestEntry(ctx context.Context, storageURL, app, appVersion string) (en
 	var latestCreated *time.Time
 	var latestEntry entry
 	for _, e := range entries {
-		if appVersion != "" && !strings.HasSuffix(e.AppVersion, appVersion) {
+		if appVersion == "" {
+			continue
+		}
+
+		if !strings.HasSuffix(e.AppVersion, appVersion) {
+			continue
+		}
+
+		if !strings.HasSuffix(e.Version, appVersion) {
 			continue
 		}
 

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -67,6 +67,8 @@ func getLatestEntry(ctx context.Context, storageURL, app, appVersion string) (en
 			continue
 		}
 
+		// appVersion could be the SHA string which is followed by the chart version.
+		// if this SHA is neither the suffix of appVersion or the suffix of version in appcatalog entry, we skip it.
 		if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
 			continue
 		}


### PR DESCRIPTION
In case we need to show the upstream version as appVersion, we should compare appVersion with `version` in appcatalog index files. 