### PR TITLE
Do not skip when app_version is not presented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop skipping entries when appVersion parameter is not presented
+
 ## [0.3.1] - 2020-11-23
 
 ### Changed

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -63,14 +63,12 @@ func getLatestEntry(ctx context.Context, storageURL, app, appVersion string) (en
 	var latestCreated *time.Time
 	var latestEntry entry
 	for _, e := range entries {
-		if appVersion == "" {
-			continue
-		}
-
-		// appVersion could be the SHA string which is followed by the chart version.
-		// if this SHA is neither the suffix of appVersion or the suffix of version in appcatalog entry, we skip it.
-		if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
-			continue
+		if appVersion != "" {
+			// appVersion could be the SHA string which is followed by the chart version.
+			// if this SHA is neither the suffix of appVersion or the suffix of version in appcatalog entry, we skip it.
+			if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
+				continue
+			}
 		}
 
 		t, err := parseTime(e.Created)


### PR DESCRIPTION
appcatalog should ignore `appVersion` when it's not presented but currently it skip whole entries if it's empty. 