### PR TITLE
Extending entry struct and only return latest entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added `GetLatestEntry` function and expose `Entry` struct.
+
 ## [0.3.2] - 2020-12-02
 
 ### Fixed

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -87,11 +87,3 @@ func getIndex(storageURL string) (index, error) {
 
 	return i, nil
 }
-
-func parseTime(created string) (*time.Time, error) {
-	t, err := time.Parse(time.RFC3339, created)
-	if err != nil {
-		return nil, microerror.Maskf(executionFailedError, "wrong timestamp format %#q", created)
-	}
-	return &t, nil
-}

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -15,6 +15,7 @@ import (
 )
 
 // GetLatestChart returns the latest chart tarball file for the specified storage URL and app
+// and returns notFoundError when it can't find a specified app.
 func GetLatestChart(ctx context.Context, storageURL, app, appVersion string) (string, error) {
 	entry, err := GetLatestEntry(ctx, storageURL, app, appVersion)
 	if err != nil {

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -1,6 +1,7 @@
 package appcatalog
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +16,29 @@ import (
 
 // GetLatestEntry returns the latest app entry for the specified storage URL and app
 // and returns notFoundError when it can't find a specified app.
-func GetLatestEntry(storageURL, app, appVersion string) (Entry, error) {
+func GetLatestChart(ctx context.Context, storageURL, app, appVersion string) (string, error) {
+	entry, err := GetLatestEntry(ctx, storageURL, app, appVersion)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return entry.Urls[0], nil
+}
+
+// GetLatestVersion returns the latest app version for the specified storage URL and app
+// and returns notFoundError when it can't find a specified app.
+func GetLatestVersion(ctx context.Context, storageURL, app, appVersion string) (string, error) {
+	entry, err := GetLatestEntry(ctx, storageURL, app, appVersion)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return entry.Version, nil
+}
+
+// GetLatestEntry returns the latest app entry for the specified storage URL and app
+// and returns notFoundError when it can't find a specified app.
+func GetLatestEntry(ctx context.Context, storageURL, app, appVersion string) (Entry, error) {
 	index, err := getIndex(storageURL)
 	if err != nil {
 		return Entry{}, microerror.Mask(err)

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -1,7 +1,6 @@
 package appcatalog
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,26 +13,42 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// GetLatestChart returns the latest chart tarball file for the specified storage URL and app
+// GetLatestEntry returns the latest app entry for the specified storage URL and app
 // and returns notFoundError when it can't find a specified app.
-func GetLatestChart(ctx context.Context, storageURL, app, appVersion string) (string, error) {
-	entry, err := getLatestEntry(ctx, storageURL, app, appVersion)
+func GetLatestEntry(storageURL, app, appVersion string) (Entry, error) {
+	index, err := getIndex(storageURL)
 	if err != nil {
-		return "", microerror.Mask(err)
+		return Entry{}, microerror.Mask(err)
 	}
 
-	return entry.Urls[0], nil
-}
-
-// GetLatestVersion returns the latest app version for the specified storage URL and app
-// and returns notFoundError when it can't find a specified app.
-func GetLatestVersion(ctx context.Context, storageURL, app, appVersion string) (string, error) {
-	entry, err := getLatestEntry(ctx, storageURL, app, appVersion)
-	if err != nil {
-		return "", microerror.Mask(err)
+	entries, ok := index.Entries[app]
+	if !ok {
+		return Entry{}, microerror.Maskf(notFoundError, "no app %#q in index.yaml", app)
 	}
 
-	return entry.Version, nil
+	var latestCreated *time.Time
+	var latestEntry Entry
+	for _, e := range entries {
+		if appVersion != "" {
+			// appVersion could be the SHA string which is followed by the chart version.
+			// if this SHA is neither the suffix of appVersion or the suffix of version in appcatalog Entry, we skip it.
+			if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
+				continue
+			}
+		}
+
+		if latestCreated == nil || e.Created.After(*latestCreated) {
+			latestCreated = &e.Created
+			latestEntry = e
+			continue
+		}
+	}
+
+	if latestEntry.Name != "" {
+		return latestEntry, nil
+	}
+
+	return Entry{}, microerror.Maskf(notFoundError, "no app %#q in index.yaml with given appVersion %#q", app, appVersion)
 }
 
 // NewTarballURL returns the chart tarball URL for the specified app and version.
@@ -47,47 +62,6 @@ func NewTarballURL(baseURL string, appName string, version string) (string, erro
 	}
 	u.Path = path.Join(u.Path, fmt.Sprintf("%s-%s.tgz", appName, version))
 	return u.String(), nil
-}
-
-func getLatestEntry(ctx context.Context, storageURL, app, appVersion string) (entry, error) {
-	index, err := getIndex(storageURL)
-	if err != nil {
-		return entry{}, microerror.Mask(err)
-	}
-
-	entries, ok := index.Entries[app]
-	if !ok {
-		return entry{}, microerror.Maskf(notFoundError, "no app %#q in index.yaml", app)
-	}
-
-	var latestCreated *time.Time
-	var latestEntry entry
-	for _, e := range entries {
-		if appVersion != "" {
-			// appVersion could be the SHA string which is followed by the chart version.
-			// if this SHA is neither the suffix of appVersion or the suffix of version in appcatalog entry, we skip it.
-			if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
-				continue
-			}
-		}
-
-		t, err := parseTime(e.Created)
-		if err != nil {
-			return entry{}, microerror.Mask(err)
-		}
-
-		if latestCreated == nil || t.After(*latestCreated) {
-			latestCreated = t
-			latestEntry = e
-			continue
-		}
-	}
-
-	if latestEntry.Name != "" {
-		return latestEntry, nil
-	}
-
-	return entry{}, microerror.Maskf(notFoundError, "no app %#q in index.yaml with given appVersion %#q", app, appVersion)
 }
 
 func getIndex(storageURL string) (index, error) {

--- a/types.go
+++ b/types.go
@@ -1,13 +1,18 @@
 package appcatalog
 
+import "time"
+
 type index struct {
-	Entries map[string][]entry `json:"entries"`
+	Entries map[string][]Entry `json:"entries"`
 }
 
-type entry struct {
-	AppVersion string   `json:"appVersion"`
-	Created    string   `json:"created"`
-	Name       string   `json:"name"`
-	Urls       []string `json:"urls"`
-	Version    string   `json:"version"`
+type Entry struct {
+	AppVersion  string    `json:"appVersion"`
+	Created     time.Time `json:"created"`
+	Description string    `json:"description"`
+	Home        string    `json:"home"`
+	Icon        string    `json:"icon"`
+	Name        string    `json:"name"`
+	Urls        []string  `json:"urls"`
+	Version     string    `json:"version"`
 }


### PR DESCRIPTION
We need more than few pieces of information from the latest appcatalog entry to make our integration test works. (e.g. home, icon, and appVersion). 
Instead of adding a new function like `GetLatestAppVersion`, Now I'm thinking it makes sense to expose the `Entry` struct directly. 