### PR TITLE
Do not compare AppVersion when getting the latest entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not compare AppVersion when getting the latest entry as it no longer
+contains the Git commit SHA.
+
 ## [0.4.0] - 2021-02-02
 
 ### Added

--- a/appcatalog.go
+++ b/appcatalog.go
@@ -66,9 +66,8 @@ func GetLatestEntry(ctx context.Context, storageURL, app, appVersion string) (En
 	var latestEntry Entry
 	for _, e := range entries {
 		if appVersion != "" {
-			// appVersion could be the SHA string which is followed by the chart version.
-			// if this SHA is neither the suffix of appVersion or the suffix of version in appcatalog Entry, we skip it.
-			if !strings.HasSuffix(e.AppVersion, appVersion) && !strings.HasSuffix(e.Version, appVersion) {
+			// If the version suffix doesn't match the SHA string we skip it.
+			if !strings.HasSuffix(e.Version, appVersion) {
 				continue
 			}
 		}


### PR DESCRIPTION
Only check the version field in the index.yaml as the appVersion no longer contains the Git SHA.