### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.7.0
 
 workflows:
   build:

--- a/helm/appcatalog/values.yaml
+++ b/helm/appcatalog/values.yaml
@@ -7,7 +7,7 @@ appCatalog:
   description: ""
   logoURL: "http://giantswarm.com/catalog-logo.png"
   storage:
-    URL: "https://giantswarm.github.com/changeme-catalog/"
+    URL: "https://giantswarm.github.io/changeme-catalog/"
   config:
     configMap:
       name: ""


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898