### PR TITLE
Merging secrets into CM on demand

### DIFF
--- a/helm/appcatalog/templates/_resource.tpl
+++ b/helm/appcatalog/templates/_resource.tpl
@@ -25,3 +25,11 @@
 {{- define "secretExists" -}}
 {{- or ( and .Values.appCatalog.config .Values.appCatalog.config.secret .Values.appCatalog.config.secret.values) ( not .Values.appCatalog.config.secret.managed ) }}
 {{- end -}}
+
+{{- define "configMapValues" -}}
+{{- if .Values.appCatalog.config.secret.mergeIntoCM -}}
+{{- mergeOverwrite .Values.appCatalog.config.configMap.values .Values.appCatalog.config.secret.values | toYaml | nindent 4 }}
+{{- else -}}
+{{ .Values.appCatalog.config.configMap.values | toYaml | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/helm/appcatalog/templates/configmap.yaml
+++ b/helm/appcatalog/templates/configmap.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "{{ .Values.appCatalog.config.configMap.namespace }}"
 data:
   values: |
-{{- toYaml .Values.appCatalog.config.configMap.values | trim | nindent 4 }}
+{{- include "configMapValues" . }}
 {{ end -}}
 {{ end -}}

--- a/helm/appcatalog/templates/secret.yaml
+++ b/helm/appcatalog/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.appCatalog.config .Values.appCatalog.config.secret }}
+{{ if and .Values.appCatalog.config .Values.appCatalog.config.secret (not .Values.appCatalog.config.secret.mergeIntoCM) }}
 {{ if and .Values.appCatalog.config.secret.managed .Values.appCatalog.config.secret.values }}
 apiVersion: v1
 kind: Secret

--- a/helm/appcatalog/values.yaml
+++ b/helm/appcatalog/values.yaml
@@ -21,4 +21,5 @@ appCatalog:
       name: ""
       namespace: "giantswarm"
       managed: true
+      mergeIntoCM: false
       values:


### PR DESCRIPTION
## Description

This PR originates from [this](https://github.com/giantswarm/giantswarm/issues/22658) issue. In general when bootstraping the Workload Cluster we install bunch of apps from `default` Catalog. This Catalog and its configuration lives in the `giantswarm` namespace, but after fixing the [security issue](https://github.com/giantswarm/giantswarm/pull/22292), WCs `app-operators` are no longer permitted to read secrets from the `giantswarm` namespace what is a problem for the `external-dns` app that is provided credentials to the AWS from the Catalog's secret.

Now, originally we tried to tackle this by moving the credentials from Catalog's Secret to ConfigMap in the [installation](https://github.com/giantswarm/installations/pull/2035) repository, this however failed because we keep credentials in an encrypted form there, and decryption works only for the things kept under the Secret's values, see [here](https://github.com/giantswarm/opsctl/blob/79041decbb20a74d50b591ea792fe80920e0a7f2/service/installation/primary.go#L768). Moving the credentials just like that resulted in delivering them to the clusters in encrypted form. So, in order to make this move, we would either need to put the credentials in an unencrypted form into the `installation` repository, or patch the `opsctl` so that it also decrypts the ConfigMap's values as well, both of which seem either time consuming or violating our security policies.

This PR should open a third way, so we should still be able to keep credentials encrypted under the Secret's values, but now we tell Helm, with the `mergeIntoCM` flag, to not put these into the Secret, but instead merge to the ConfigMap's values.